### PR TITLE
added redirected bool to tree struct to know whether redirect operator is already executed

### DIFF
--- a/include/minishell.h
+++ b/include/minishell.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   minishell.h                                        :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: fschuber <fschuber@student.42.fr>          +#+  +:+       +#+        */
+/*   By: nburchha <nburchha@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/01/30 11:30:11 by fschuber          #+#    #+#             */
-/*   Updated: 2024/04/25 10:38:26 by fschuber         ###   ########.fr       */
+/*   Updated: 2024/04/25 11:59:34 by nburchha         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -74,6 +74,7 @@ typedef struct s_bin_tree_node
 	t_bin_tree_node	*l;
 	t_bin_tree_node	*r;
 	t_bin_tree_node	*parent;
+	bool			redirected; // true if node is a redirection and was already executed
 	int				input_fd;
 	int				output_fd;
 }	t_bin_tree_node;

--- a/src/3-parsing/parser.c
+++ b/src/3-parsing/parser.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   parser.c                                           :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: fschuber <fschuber@student.42heilbronn.    +#+  +:+       +#+        */
+/*   By: nburchha <nburchha@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/08 12:13:31 by fschuber          #+#    #+#             */
-/*   Updated: 2024/03/26 05:34:23 by fschuber         ###   ########.fr       */
+/*   Updated: 2024/04/25 11:59:50 by nburchha         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -128,6 +128,7 @@ t_bin_tree_node	*tok_to_bin_tree(t_list *tokens, t_program_data *program_data)
 	gc_append_element(program_data->gc, node);
 	node->input_fd = STDIN_FILENO;
 	node->output_fd = STDOUT_FILENO;
+	node->redirected = false;
 	dom_op_i = get_dominant_operator(&tokens);
 	if (dom_op_i == -1)
 	{

--- a/src/4-executing/executer.c
+++ b/src/4-executing/executer.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   executer.c                                         :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: fschuber <fschuber@student.42.fr>          +#+  +:+       +#+        */
+/*   By: nburchha <nburchha@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/02/20 12:44:43 by fschuber          #+#    #+#             */
-/*   Updated: 2024/04/25 10:28:40 by fschuber         ###   ########.fr       */
+/*   Updated: 2024/04/25 12:15:12 by nburchha         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -169,9 +169,14 @@ pid_t	execute(t_bin_tree_node *tree, t_program_data *program_data, t_pid_list **
 		else if (tree->val[0]->type == TOK_REDIR)
 			if (redirect(tree, program_data) == 1 || !tree->l)
 				return (last_pid);
+		if (tree->val[0]->type == TOK_REDIR && tree->r->val[0]->type == TOK_REDIR && ((tree->l && tree->l->val[0]->type < tree->r->val[0]->type) || (tree->parent && tree->parent->val[0]->type == TOK_REDIR)))
+			if (redirect(tree->r, program_data) == 1)
+				return (last_pid);
 		last_pid = execute(tree->l, program_data, pid_list);
-		if (tree->val[0]->type == TOK_PIPE)
+		if (tree->val[0]->type == TOK_PIPE && tree->r->redirected == false)
 			last_pid = execute(tree->r, program_data, pid_list);
 	}
 	return (last_pid);
 }
+
+//ls | cat << stop <- executen cat nicht

--- a/src/4-executing/operators/redirect.c
+++ b/src/4-executing/operators/redirect.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   redirect.c                                         :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: fschuber <fschuber@student.42.fr>          +#+  +:+       +#+        */
+/*   By: nburchha <nburchha@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/03/01 16:07:34 by nburchha          #+#    #+#             */
-/*   Updated: 2024/04/25 09:50:26 by fschuber         ###   ########.fr       */
+/*   Updated: 2024/04/25 12:16:17 by nburchha         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -87,6 +87,7 @@ int	redirect(t_bin_tree_node *node, t_program_data *program_data)
 	char	*filename;
 	bool	redir_out;
 
+	node->redirected = true;
 	if (node->input_fd != 0 && node->val[0]->value[0] == '>' && node->l)
 		node->l->input_fd = node->input_fd;
 	else if (node->input_fd != 0)


### PR DESCRIPTION
fixes the behavior of:
ls | cat << stop
cat < Makefile > out
echo > out > out1 > out2 > out3

testcases: 2709/108 stdout:31 stderr:9 exitcode: 68